### PR TITLE
Re-enable static linking for libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(venmic LANGUAGES CXX VERSION 6.1.0)
 option(venmic_addon         "Build as addon"                            OFF)
 option(venmic_server        "Build as rest server"                       ON)
 option(venmic_prefer_remote "Prefer remote packages over local packages" ON)
+option(venmic_static_cxx    "Static link libstdc++ and libgcc"          OFF)
 
 # --------------------------------------------------------------------------------------------------------
 # Addon and Rest-Server are mutually exclusive
@@ -154,4 +155,8 @@ endif()
 
 if (venmic_addon)
   add_subdirectory(addon)
+endif()
+
+if (venmic_static_cxx)
+  target_link_libraries(${PROJECT_NAME} PRIVATE -static-libgcc -static-libstdc++)
 endif()

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -10,4 +10,4 @@ cd /work
 export MAKEFLAGS=-j$(nproc)
 export PARALLEL_LEVEL=$(nproc)
 
-pnpm install --ignore-scripts && pnpm run install
+pnpm install --ignore-scripts && pnpm run install:static

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean": "cmake-js clean",
     "test": "node tests/node/*.js",
     "cpcmds": "cmake-js configure --CDvenmic_addon=ON --CDCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-    "install": "pkg-prebuilds-verify ./lib/options.js || cmake-js compile --CDvenmic_addon=ON"
+    "install": "pkg-prebuilds-verify ./lib/options.js || cmake-js compile --CDvenmic_addon=ON",
+    "install:static": "pkg-prebuilds-verify ./lib/options.js || cmake-js compile --CDvenmic_addon=ON --CDvenmic_static_cxx=ON"
   },
   "os": [
     "linux"


### PR DESCRIPTION
Many Linux distributions such as Debian 12 fail to run venmic since they lack a new enough libstdc++ version. This issue can be worked around by statically linking libstdc++.

I did notice that this feature was originally removed in [this commit](https://github.com/Vencord/venmic/commit/58f0f8f1eaeddf753c77830d958ccec9517207f0), but I'm unsure as to what the reasoning behind that was. In the testing that I did, statically linking libstdc++ caused no additional problems, and it allowed venmic to function correctly on Debian 12 without needing to resort to using the Vesktop Flatpak package. 